### PR TITLE
bug fix: #to_string should be #to_s

### DIFF
--- a/lib/opener/kaf_to_json.rb
+++ b/lib/opener/kaf_to_json.rb
@@ -45,7 +45,7 @@ module Opener
       begin
         doc = Saxon::XML(input)
         xslt = Saxon::XSLT(File.read(xsl))
-        return xslt.transform(doc).to_string
+        return xslt.transform(doc).to_s
         
       rescue Exception => error
         return Opener::Core::ErrorLayer.new(input, error.message, self.class).add


### PR DESCRIPTION
When I was running I was gettting undefined `to_string` so I changed it to `to_s` and it appears to work. Which makes sense since in ruby it should be `to_s`.
