### PR TITLE
Make the service runnable in Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.git/
+.gitignore
+.ruby-version
+.travis.yml
+Dockerfile
+LICENSE.txt
+README.md
+reference.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM jruby:9-alpine
+
+RUN apk add --no-cache libarchive-dev \
+ && rm -rf /var/lib/apt/lists/*
+
+ADD . /app
+
+WORKDIR /app
+RUN bundle install --without development
+
+EXPOSE 80
+CMD ["/usr/local/bin/ruby", "/usr/local/bundle/bin/kaf2json-server", "-p", "80"]

--- a/README.md
+++ b/README.md
@@ -68,6 +68,12 @@ Documentation on the Webservice is provided by surfing to the urls provided
 above. For more information on how to launch a webservice run the command with
 the `--help` option.
 
+You can also launch the webservice via Docker:
+
+    docker run -d -p 8080:80 cwolff/opener-docker-kaf2json
+
+This launches the server at <http://localhost:8080>
+
 ### Daemon
 
 Last but not least the kaf2json comes shipped with a daemon that can read jobs

--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -1,0 +1,124 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "site_name": {
+      "defaultValue": "opener-kaf2json",
+      "type": "string"
+    },
+    "appserviceplan_size": {
+      "defaultValue": "S2",
+      "type": "string",
+      "allowedValues": [
+        "S1",
+        "S2",
+        "S3"
+      ]
+    }
+  },
+  "variables": {
+    "location": "[resourceGroup().location]",
+    "appserviceplan_name": "[concat(parameters('site_name'), '-plan')]"
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Web/serverfarms",
+      "sku": {
+        "name": "[parameters('appserviceplan_size')]",
+        "tier": "Standard",
+        "size": "[parameters('appserviceplan_size')]",
+        "family": "S",
+        "capacity": 1
+      },
+      "kind": "linux",
+      "name": "[variables('appserviceplan_name')]",
+      "apiVersion": "2016-09-01",
+      "location": "[variables('location')]",
+      "properties": {
+        "workerSizeId": 0,
+        "reserved": true,
+        "hostingEnvironment": ""
+      },
+      "dependsOn": []
+    },
+    {
+      "type": "Microsoft.Web/sites",
+      "kind": "app,linux",
+      "name": "[parameters('site_name')]",
+      "apiVersion": "2016-08-01",
+      "location": "[variables('location')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.Web/serverfarms', variables('appserviceplan_name'))]"
+      ],
+      "tags": {},
+      "scale": null,
+      "properties": {
+        "name": "[parameters('site_name')]",
+        "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('appserviceplan_name'))]",
+        "httpLoggingEnabled": true,
+        "logsDirectorySizeLimit": 35
+      },
+      "resources": [
+        {
+          "name": "appsettings",
+          "type": "config",
+          "apiVersion": "2016-08-01",
+          "dependsOn": [
+            "[resourceId('Microsoft.Web/sites', parameters('site_name'))]"
+          ],
+          "tags": {
+            "displayName": "appSettings"
+          },
+          "properties": {
+            "DOCKER_CUSTOM_IMAGE_NAME": "cwolff/opener-docker-kaf2json",
+            "WEBSITES_ENABLE_APP_SERVICE_STORAGE": "false"
+          }
+        },
+        {
+          "name": "logs",
+          "type": "config",
+          "apiVersion": "2016-08-01",
+          "tags": {},
+          "dependsOn": [
+            "[resourceId('Microsoft.Web/sites', parameters('site_name'))]"
+          ],
+          "properties": {
+            "applicationLogs": {
+              "fileSystem": {
+                "level": "Off"
+              },
+              "azureTableStorage": {
+                "level": "Off",
+                "sasUrl": null
+              },
+              "azureBlobStorage": {
+                "level": "Off",
+                "sasUrl": null,
+                "retentionInDays": null
+              }
+            },
+            "httpLogs": {
+              "fileSystem": {
+                "retentionInMb": 35,
+                "retentionInDays": 7,
+                "enabled": true
+              },
+              "azureBlobStorage": {
+                "sasUrl": null,
+                "retentionInDays": 7,
+                "enabled": false
+              }
+            },
+            "failedRequestsTracing": {
+              "enabled": false
+            },
+            "detailedErrorMessages": {
+              "enabled": false
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "outputs": {}
+}

--- a/opener-kaf2json.gemspec
+++ b/opener-kaf2json.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency 'builder'
   gem.add_dependency 'nokogiri'
-  gem.add_dependency 'saxon-xslt'
+  gem.add_dependency 'saxon-xslt', '< 0.8.0'
   gem.add_dependency 'slop', '~> 3.5'
   gem.add_dependency 'rumoji'
 


### PR DESCRIPTION
This pull request enables the `kaf2json-server` to be run in a Docker container. This eases development setup and also production deployment of the service.

Additionally, the pull request also:

- Pins the `saxon-xslt` dependency since newer versions caused an exception "XSLT 1.0 compatibility mode is not available".

- Adds an [ARM template](https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-group-overview) for easy deployment of the kaf2json service to [Azure PaaS](https://azure.microsoft.com/en-us/services/app-service/containers/).